### PR TITLE
fix: Create backend-only Docker deployment for Render

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,28 +1,84 @@
-# Reduce build context size
-node_modules
-**/node_modules
-**/.next
-**/dist
-**/out
+# Docker ignore file for backend-only builds
+# Exclude frontend and development files
+
+# Frontend directories (deployed separately on Vercel)
+frontend/
+frontend-nextjs/
+New folder/
+
+# Git and version control
 .git
 .gitignore
-__pycache__
+
+# Development environment files
+.env
+.env.local
+.env.staging
+.env.render.template
+
+# IDE and editor files
+.vscode/
+.idea/
+*.swp
+*.swo
+.DS_Store
+
+# Python cache and build artifacts
+__pycache__/
 *.pyc
 *.pyo
 *.pyd
-*.so
-*.egg-info
-.env
-.env.*
-.DS_Store
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Testing and coverage
+.coverage
+.pytest_cache/
+.tox/
+.coverage/
+htmlcov/
+
+# Node.js (not needed for backend)
+node_modules/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
-pnpm-debug.log*
-.idea
-.vscode
-coverage
-pytest_cache
+.npm
+.next/
+
+# Documentation and guides
+*.md
+docs/
+
+# Audio test files
 *.wav
 *.mp3
-*.zip
+*.mp4
+audio/
+
+# Logs
+*.log
+logs/
+
+# Deployment files for other platforms
+fly.toml
+vercel.json
+docker-compose.yml
+
+# Temporary files
+*.tmp
+*.temp

--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -1,0 +1,47 @@
+# syntax=docker/dockerfile:1
+
+# ---------------------------
+# Backend-Only Dockerfile for Render Deployment
+# (Frontend is deployed separately on Vercel)
+# ---------------------------
+
+FROM python:3.10-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PYTHONPATH=/app
+
+WORKDIR /app
+
+# Install system dependencies for audio processing
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ffmpeg \
+    libsndfile1 \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Python dependencies
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy backend code only
+COPY main.py ./
+COPY app/ ./app/
+COPY *.sql ./
+COPY grafana-dashboards/ ./grafana-dashboards/
+
+# Create non-root user for security
+RUN useradd --create-home --shell /bin/bash sophia && \
+    chown -R sophia:sophia /app
+USER sophia
+
+# Health check for backend
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+    CMD curl -f http://localhost:${PORT:-8000}/health || exit 1
+
+# Use PORT environment variable (Render sets this)
+ENV PORT=8000
+EXPOSE $PORT
+
+# Start only the FastAPI backend
+CMD uvicorn main:app --host 0.0.0.0 --port ${PORT:-8000}

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,10 @@
+services:
+  - type: web
+    name: sophia-backend
+    env: docker
+    plan: starter
+    # Use backend-only Dockerfile 
+    dockerfilePath: ./Dockerfile.backend
+    healthCheckPath: /health
+    # Auto-deploy after successful manual deploy
+    autoDeploy: false


### PR DESCRIPTION
ISSUE: Render deployment failing due to frontend build in Dockerfile
SOLUTION: Separate backend and frontend deployments

Changes:
- Create Dockerfile.backend for backend-only deployment
- Update render.yaml to use dockerfilePath: ./Dockerfile.backend
- Add .dockerignore to exclude frontend files from Docker context
- Remove frontend build stages and Node.js dependencies
- Optimize for Python FastAPI backend only

Key Improvements:
- Faster build times (no frontend compilation)
- Smaller Docker image size (no Node.js/npm)
- Clear separation of concerns (backend on Render, frontend on Vercel)
- Resolves 'npm run build' failure in Render deployment

Deployment Architecture:
- Backend: Render.com (Docker) → https://sophia-1st-mvp-xjml.onrender.com
- Frontend: Vercel (Next.js) → https://sophia-1st-mvp-git-main-davidelavergas-projects.vercel.app

Testing:
- Dockerfile.backend includes all required backend components
- Health check endpoint: /health
- Port configuration: uses Render's  environment variable
- Security: non-root user sophia for container execution