### PR TITLE
fix: Replace Dockerfile with backend-only version for Render

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,6 +8,12 @@ node_modules
 .gitignore
 __pycache__
 *.pyc
+
+# CRITICAL: Frontend exclusion (deployed separately on Vercel)
+frontend/
+frontend-nextjs/
+**/frontend/
+**/frontend-nextjs/
 *.pyo
 *.pyd
 *.so


### PR DESCRIPTION
ISSUE: Render using original multi-stage Dockerfile trying to build frontend
SOLUTION: Replace main Dockerfile with backend-only version

Root Cause Analysis:
- Render was ignoring render.yaml dockerfilePath setting
- Still using original Dockerfile with frontend-builder stage
- Error: '/frontend-nextjs': not found during COPY command
- Frontend should only be on Vercel, not Render

Changes:
- Replace Dockerfile with backend-only version (no frontend stages)
- Backup original as Dockerfile.original
- Update .dockerignore to explicitly exclude frontend directories
- Remove Node.js, npm, and frontend build steps
- Use python:3.10-slim base image only
- Copy only backend files (main.py, app/, *.sql)

Benefits:
- No more frontend build errors
- Faster deployment (no Node.js/npm operations)
- Smaller Docker image
- Clear separation: backend (Render) + frontend (Vercel)

Expected Result:
- Successful Docker build with Python FastAPI only
- No 'frontend-nextjs not found' errors
- Backend accessible at /health endpoint