### PR TITLE
fix: Remove invalid shell redirection from Dockerfile COPY command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,7 @@
-# syntax=docker/dockerfile:1
+# Backend-Only Dockerfile for Render Deployment
+# Frontend is deployed separately on Vercel
 
-# ---------------------------
-# Stage 1: Build Next.js (standalone)
-# ---------------------------
-FROM node:18-alpine AS frontend-builder
-WORKDIR /app/frontend-nextjs
-COPY frontend-nextjs/package*.json ./
-RUN npm ci
-COPY frontend-nextjs/ ./
-# Build Next.js with standalone output
-RUN npm run build
-
-# ---------------------------
-# Stage 2: Final runtime (Node + Python slim)
-# ---------------------------
-FROM node:18-slim AS runtime
+FROM python:3.10-slim
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
@@ -22,51 +9,39 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 WORKDIR /app
 
-# Install Python + minimal system deps needed for audio
+# Install system dependencies for audio processing
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    python3 python3-pip python3-venv \
     ffmpeg \
     libsndfile1 \
+    curl \
     && rm -rf /var/lib/apt/lists/*
 
-# Create a dedicated virtualenv to avoid PEP 668 restrictions
-RUN python3 -m venv /opt/venv
-ENV PATH="/opt/venv/bin:${PATH}"
-
-# Install Python dependencies in the venv (better layer caching if requirements.txt unchanged)
+# Install Python dependencies
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 
-# Copy backend code (root contains main.py and app/)
-COPY . .
+# Copy backend code only (no frontend)
+COPY main.py ./
+COPY app/ ./app/
 
-# Copy only the minimal Next.js standalone artifacts to keep image small
-# - standalone server
-# - static assets
-# - public assets
-RUN mkdir -p /opt/next
-COPY --from=frontend-builder /app/frontend-nextjs/.next/standalone /opt/next/
-COPY --from=frontend-builder /app/frontend-nextjs/.next/static /opt/next/.next/static
-# Project has no frontend-nextjs/public directory; create an empty one to be safe
-RUN mkdir -p /opt/next/public
+# Copy SQL files if they exist
+COPY *.sql ./
 
-# Install a small process manager
-RUN npm install -g concurrently
+# Copy grafana-dashboards directory if it exists
+COPY grafana-dashboards/ ./grafana-dashboards/
 
 # Create non-root user for security
 RUN useradd --create-home --shell /bin/bash sophia && \
-    chown -R sophia:sophia /app /opt/next
+    chown -R sophia:sophia /app
 USER sophia
 
-# Health check (backend only)
+# Health check for backend
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD python3 -c "import requests; requests.get('http://localhost:8000/health')"
+    CMD curl -f http://localhost:${PORT:-8000}/health || exit 1
 
-# Fly will set PORT; default to 8000 locally
+# Use PORT environment variable (Render sets this)
 ENV PORT=8000
-EXPOSE 8000
+EXPOSE $PORT
 
-# Start both processes:
-# - FastAPI on 8000 (exposed)
-# - Next.js standalone server on 3000 (internal)
-CMD ["sh", "-c", "concurrently \"uvicorn main:app --host 0.0.0.0 --port ${PORT:-8000}\" \"sh -lc 'cd /opt/next && node server.js -p 3000 -H 0.0.0.0'\""]
+# Start only the FastAPI backend
+CMD uvicorn main:app --host 0.0.0.0 --port ${PORT:-8000}


### PR DESCRIPTION
ISSUE: Docker build failing with shell redirection in COPY command
ERROR: Line 30 - COPY grafana-dashboards/ ./grafana-dashboards/ 2>/dev/null || true

Root Cause:
- Docker COPY commands don't support shell operators (2>/dev/null || true)
- Shell redirection only works in RUN commands, not COPY commands
- Causes Docker cache key calculation failure

Solution:
- Remove shell redirection from COPY command
- Use simple COPY grafana-dashboards/ ./grafana-dashboards/
- Directory exists in repository, so no conditional logic needed
- Restore backend-only Dockerfile (was reverted to multi-stage in merge)

Changes:
- Replace multi-stage Dockerfile with backend-only version
- Remove frontend build stages (Node.js, npm, frontend-nextjs)
- Fix COPY command syntax error on line 30
- Use python:3.10-slim base image only
- Remove shell operators from COPY commands

Expected Result:
- Successful Docker build with no syntax errors
- Backend-only container deployment on Render
- No more cache key calculation failures