### PR TITLE
fix: OAuth callback redirecting to wrong origin (Render instead of Ve…

### DIFF
--- a/frontend-nextjs/app/auth/callback/route.ts
+++ b/frontend-nextjs/app/auth/callback/route.ts
@@ -6,9 +6,19 @@ export async function GET(request: NextRequest) {
   const requestUrl = new URL(request.url)
   const code = requestUrl.searchParams.get('code')
   const error = requestUrl.searchParams.get('error')
-  const origin = requestUrl.origin
+  
+  // CRITICAL FIX: Use correct Vercel origin instead of potentially wrong requestUrl.origin
+  const origin = process.env.NODE_ENV === 'production' 
+    ? 'https://sophia-1st-mvp-git-main-davidelavergas-projects.vercel.app'
+    : requestUrl.origin
 
-  console.log('🔄 Auth callback received:', { code: !!code, error, origin })
+  console.log('🔄 Auth callback received:', { 
+    code: !!code, 
+    error, 
+    origin,
+    requestOrigin: requestUrl.origin,
+    env: process.env.NODE_ENV 
+  })
 
   if (error) {
     console.error('❌ OAuth error from Discord:', error)


### PR DESCRIPTION
…rcel)

ISSUE: After Discord auth, user redirected to backend URL instead of frontend
ROOT CAUSE: auth/callback/route.ts using requestUrl.origin which points to wrong domain

Changes:
- CRITICAL FIX: Hardcode Vercel origin in production environment
- Use conditional logic: production = Vercel URL, development = dynamic origin
- Add detailed logging to debug origin resolution
- Prevent redirect to Render backend after OAuth success

Before: requestUrl.origin (could be backend URL)
After: Explicit Vercel URL in production

Expected Result:
- Discord auth completes on frontend (Vercel)
- User stays on frontend after auth callback
- No more redirects to Render backend
- Proper UI loads after successful authentication

Architecture Fix:
User → Discord → Vercel /auth/callback → Vercel / (frontend) ✅ NOT: User → Discord → Vercel /auth/callback → Render backend ❌