### PR TITLE
fix: Improve consent error handling and add detailed logging

### DIFF
--- a/frontend-nextjs/app/api/consent/accept/route.ts
+++ b/frontend-nextjs/app/api/consent/accept/route.ts
@@ -4,7 +4,26 @@ import { cookies } from 'next/headers'
 import { createHash } from 'crypto'
 
 export async function POST(request: NextRequest) {
+  console.log('📝 Consent accept request received')
+  
   try {
+    // Verify environment variables are set
+    if (!process.env.NEXT_PUBLIC_SUPABASE_URL) {
+      console.error('❌ NEXT_PUBLIC_SUPABASE_URL is not set')
+      return NextResponse.json({ error: 'Server configuration error' }, { status: 500 })
+    }
+    if (!process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY) {
+      console.error('❌ NEXT_PUBLIC_SUPABASE_ANON_KEY is not set')
+      return NextResponse.json({ error: 'Server configuration error' }, { status: 500 })
+    }
+    if (!process.env.SUPABASE_SERVICE_ROLE_KEY) {
+      console.error('❌ SUPABASE_SERVICE_ROLE_KEY is not set')
+      return NextResponse.json({ error: 'Server configuration error' }, { status: 500 })
+    }
+
+    console.log('✅ Environment variables verified')
+    console.log('📍 Supabase URL:', process.env.NEXT_PUBLIC_SUPABASE_URL)
+
     const cookieStore = cookies()
     const supabase = createServerClient(
       process.env.NEXT_PUBLIC_SUPABASE_URL!,
@@ -25,11 +44,20 @@ export async function POST(request: NextRequest) {
     )
 
     // Get current user session
+    console.log('🔍 Fetching user session...')
     const { data: { session }, error: sessionError } = await supabase.auth.getSession()
     
-    if (sessionError || !session?.user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    if (sessionError) {
+      console.error('❌ Session error:', sessionError)
+      return NextResponse.json({ error: 'Unauthorized - session error' }, { status: 401 })
     }
+    
+    if (!session?.user) {
+      console.error('❌ No user session found')
+      return NextResponse.json({ error: 'Unauthorized - no session' }, { status: 401 })
+    }
+
+    console.log('✅ User session found:', session.user.id)
 
     const body = await request.json()
     const { userId, timestamp } = body
@@ -38,12 +66,17 @@ export async function POST(request: NextRequest) {
     const discordId = session.user.user_metadata?.provider_id || session.user.user_metadata?.sub
 
     if (!discordId) {
+      console.error('❌ Discord ID not found in user metadata')
+      console.log('User metadata:', JSON.stringify(session.user.user_metadata))
       return NextResponse.json({ error: 'Discord ID not found' }, { status: 404 })
     }
+
+    console.log('✅ Discord ID found:', discordId)
 
     // Get client IP
     const forwarded = request.headers.get('x-forwarded-for')
     const ip = forwarded ? forwarded.split(',')[0] : request.headers.get('x-real-ip') || 'unknown'
+    console.log('📍 Client IP:', ip)
 
     // Convert ISO timestamp to Unix timestamp (bigint)
     const unixTimestamp = Math.floor(new Date(timestamp).getTime() / 1000)
@@ -51,8 +84,10 @@ export async function POST(request: NextRequest) {
     // Create consent hash
     const consentData = `${discordId}:${timestamp}:${ip}`
     const consentHash = createHash('sha256').update(consentData).digest('hex')
+    console.log('🔐 Consent hash generated:', consentHash.substring(0, 16) + '...')
 
     // Create service role client for database operations
+    console.log('🔑 Creating service role client...')
     const serviceSupabase = createServerClient(
       process.env.NEXT_PUBLIC_SUPABASE_URL!,
       process.env.SUPABASE_SERVICE_ROLE_KEY!,
@@ -66,14 +101,20 @@ export async function POST(request: NextRequest) {
     )
 
     // Check if consent already exists
-    const { data: existingConsent } = await serviceSupabase
+    console.log('🔍 Checking for existing consent...')
+    const { data: existingConsent, error: checkError } = await serviceSupabase
       .from('user_consents')
       .select('discord_id')
       .eq('discord_id', discordId)
       .single()
 
+    if (checkError && checkError.code !== 'PGRST116') {
+      // PGRST116 = not found, which is expected for new users
+      console.error('❌ Error checking existing consent:', checkError)
+    }
+
     if (existingConsent) {
-      // User already has consent, just return success
+      console.log('✅ Consent already exists for user')
       return NextResponse.json({ 
         success: true,
         message: 'Consent already exists'
@@ -81,28 +122,46 @@ export async function POST(request: NextRequest) {
     }
 
     // Store new consent record
-    const { error } = await serviceSupabase
-      .from('user_consents')
-      .insert({
-        discord_id: discordId,
-        consent_hash: consentHash,
-        ip_address: ip,
-        timestamp: unixTimestamp,
-        created_at: new Date().toISOString(),
-        updated_at: new Date().toISOString()
-      })
+    console.log('💾 Inserting new consent record...')
+    const consentRecord = {
+      discord_id: discordId,
+      consent_hash: consentHash,
+      ip_address: ip,
+      timestamp: unixTimestamp,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString()
+    }
+    console.log('📄 Consent record:', JSON.stringify(consentRecord, null, 2))
 
-    if (error) {
+    const { data: insertedData, error: insertError } = await serviceSupabase
+      .from('user_consents')
+      .insert(consentRecord)
+      .select()
+
+    if (insertError) {
+      console.error('❌ Database insert error:', insertError)
+      console.error('Error code:', insertError.code)
+      console.error('Error message:', insertError.message)
+      console.error('Error details:', insertError.details)
+      console.error('Error hint:', insertError.hint)
+      
       // Handle duplicate key error gracefully
-      if (error.code === '23505') {
+      if (insertError.code === '23505') {
+        console.log('⚠️ Duplicate key error - consent already exists')
         return NextResponse.json({ 
           success: true,
           message: 'Consent already exists'
         })
       }
-      console.error('Consent storage error:', error)
-      return NextResponse.json({ error: 'Failed to store consent' }, { status: 500 })
+      
+      return NextResponse.json({ 
+        error: 'Failed to store consent',
+        details: insertError.message 
+      }, { status: 500 })
     }
+
+    console.log('✅ Consent recorded successfully!')
+    console.log('Inserted data:', insertedData)
 
     return NextResponse.json({ 
       success: true,

--- a/frontend-nextjs/app/components/ConsentModal.tsx
+++ b/frontend-nextjs/app/components/ConsentModal.tsx
@@ -35,13 +35,30 @@ export default function ConsentModal({ onAccept, onClose }: ConsentModalProps) {
       })
 
       if (response.ok) {
+        console.log('✅ Consent saved successfully')
         onAccept()
       } else {
-        const data = await response.json()
-        setError(data.message || 'Failed to save consent')
+        // Log error but still allow user to continue
+        const data = await response.json().catch(() => ({ error: 'Unknown error' }))
+        console.warn('⚠️ Failed to save consent, but allowing user to continue:', data.error)
+        setError('Could not save consent record. Your session will continue, but you may be asked again.')
+        
+        // Allow user to continue after 3 seconds even if save fails
+        setTimeout(() => {
+          console.log('⚠️ Allowing user to continue despite consent save failure')
+          onAccept()
+        }, 3000)
       }
     } catch (err) {
-      setError('Network error occurred')
+      // Log error but still allow user to continue
+      console.error('❌ Network error saving consent, but allowing user to continue:', err)
+      setError('Network error. You can still use Sophia, but consent was not recorded.')
+      
+      // Allow user to continue after 3 seconds even if save fails
+      setTimeout(() => {
+        console.log('⚠️ Allowing user to continue despite network error')
+        onAccept()
+      }, 3000)
     } finally {
       setIsSubmitting(false)
     }


### PR DESCRIPTION
- Allow users to continue using app even if consent save fails (timeout after 3s)
- Add comprehensive logging to consent accept and check endpoints
- Log environment variables, user session, Discord ID, and database operations
- Better error messages for users when consent fails
- Graceful fallback to allow app usage while logging errors for debugging

This improves UX by not blocking users and helps diagnose the consent save issue.