### PR TITLE
fix: Use getUser() instead of getSession() for server-side auth

### DIFF
--- a/frontend-nextjs/app/api/consent/accept/route.ts
+++ b/frontend-nextjs/app/api/consent/accept/route.ts
@@ -43,31 +43,32 @@ export async function POST(request: NextRequest) {
       }
     )
 
-    // Get current user session
-    console.log('🔍 Fetching user session...')
-    const { data: { session }, error: sessionError } = await supabase.auth.getSession()
+    // Get current user (server-side method)
+    // Note: Using getUser() instead of getSession() for server-side validation
+    console.log('🔍 Fetching authenticated user...')
+    const { data: { user }, error: userError } = await supabase.auth.getUser()
     
-    if (sessionError) {
-      console.error('❌ Session error:', sessionError)
-      return NextResponse.json({ error: 'Unauthorized - session error' }, { status: 401 })
+    if (userError) {
+      console.error('❌ User authentication error:', userError)
+      return NextResponse.json({ error: 'Unauthorized - authentication error' }, { status: 401 })
     }
     
-    if (!session?.user) {
-      console.error('❌ No user session found')
-      return NextResponse.json({ error: 'Unauthorized - no session' }, { status: 401 })
+    if (!user) {
+      console.error('❌ No authenticated user found')
+      return NextResponse.json({ error: 'Unauthorized - no user' }, { status: 401 })
     }
 
-    console.log('✅ User session found:', session.user.id)
+    console.log('✅ Authenticated user found:', user.id)
 
     const body = await request.json()
     const { userId, timestamp } = body
 
     // Get user's Discord ID from auth metadata
-    const discordId = session.user.user_metadata?.provider_id || session.user.user_metadata?.sub
+    const discordId = user.user_metadata?.provider_id || user.user_metadata?.sub
 
     if (!discordId) {
       console.error('❌ Discord ID not found in user metadata')
-      console.log('User metadata:', JSON.stringify(session.user.user_metadata))
+      console.log('User metadata:', JSON.stringify(user.user_metadata))
       return NextResponse.json({ error: 'Discord ID not found' }, { status: 404 })
     }
 

--- a/frontend-nextjs/app/api/consent/check/route.ts
+++ b/frontend-nextjs/app/api/consent/check/route.ts
@@ -34,24 +34,25 @@ async function handleConsentCheck(request: NextRequest) {
       }
     )
 
-    // Get current user session
-    console.log('🔍 Fetching user session...')
-    const { data: { session }, error: sessionError } = await supabase.auth.getSession()
+    // Get current user (server-side method)
+    // Note: Using getUser() instead of getSession() for server-side validation
+    console.log('🔍 Fetching authenticated user...')
+    const { data: { user }, error: userError } = await supabase.auth.getUser()
     
-    if (sessionError) {
-      console.error('❌ Session error:', sessionError)
+    if (userError) {
+      console.error('❌ User authentication error:', userError)
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
     
-    if (!session?.user) {
-      console.error('❌ No user session found')
+    if (!user) {
+      console.error('❌ No authenticated user found')
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
 
-    console.log('✅ User session found:', session.user.id)
+    console.log('✅ Authenticated user found:', user.id)
 
     // Get user's Discord ID from auth metadata
-    const discordId = session.user.user_metadata?.provider_id || session.user.user_metadata?.sub
+    const discordId = user.user_metadata?.provider_id || user.user_metadata?.sub
 
     if (!discordId) {
       console.warn('⚠️ Discord ID not found, returning hasConsent: false')


### PR DESCRIPTION
BREAKING ISSUE FIX: Resolves Vercel warning and authentication issues

The Vercel logs showed a critical warning:
'Using the user object as returned from supabase.auth.getSession()'

This is a security/reliability issue. On server-side routes, we must use getUser() which validates the JWT, not getSession() which just reads cookies.

Changes:
- Replace supabase.auth.getSession() with supabase.auth.getUser()
- Update all references from session.user to user
- Maintains all existing logging and error handling

This should fix the consent storage issue where user data wasn't being saved.

Refs: https://supabase.com/docs/guides/auth/server-side/nextjs