### PR TITLE
fix: Remove non-existent columns from user insert (avatar_url, timest…

### DIFF
--- a/frontend-nextjs/app/api/consent/accept/route.ts
+++ b/frontend-nextjs/app/api/consent/accept/route.ts
@@ -138,28 +138,35 @@ export async function POST(request: NextRequest) {
     if (!existingUser) {
       console.log('👤 User not found in users table, creating new user...')
       
-      // Get additional user info from Discord OAuth metadata
+      // Get username from Discord OAuth metadata
+      // Try multiple possible locations
       const username = user.user_metadata?.full_name || 
                       user.user_metadata?.name || 
                       user.user_metadata?.preferred_username ||
+                      user.user_metadata?.username ||
                       `user_${discordIdString}`
+      
       const email = user.email || null
-      const avatarUrl = user.user_metadata?.avatar_url || 
-                       user.user_metadata?.picture || 
-                       null
 
       console.log('📋 Creating user with:', { discord_id: discordIdString, username, email })
 
+      // Only insert columns that exist in the users table schema
+      // Based on error: avatar_url, created_at, updated_at may not exist
+      const userRecord: any = {
+        discord_id: discordIdString,
+        username: username
+      }
+
+      // Add email only if provided
+      if (email) {
+        userRecord.email = email
+      }
+
+      console.log('📋 User record to insert:', userRecord)
+
       const { data: newUser, error: userInsertError } = await serviceSupabase
         .from('users')
-        .insert({
-          discord_id: discordIdString,
-          username: username,
-          email: email,
-          avatar_url: avatarUrl,
-          created_at: new Date().toISOString(),
-          updated_at: new Date().toISOString()
-        })
+        .insert(userRecord)
         .select()
         .single()
 


### PR DESCRIPTION
…amps)

SCHEMA MISMATCH FIX - Error PGRST204:
- Error: Could not find 'avatar_url' column in users table
- Root cause: Code tried to insert columns that don't exist in schema

SOLUTION:
1. Removed avatar_url field (doesn't exist in users table)
2. Removed created_at, updated_at (may not exist or have defaults)
3. Only insert columns that actually exist: discord_id, username, email
4. Build user record dynamically, only add email if provided
5. Added more username fallback locations

WHAT THIS FIXES:
- Prevents PGRST204 error (column not found in schema)
- Successful user creation in users table
- Allows consent insertion to proceed
- No more schema cache errors

CHANGES:
- Removed: avatar_url, created_at, updated_at from insert
- Kept: discord_id (required), username (required), email (optional)
- Dynamic record building for flexibility
- Enhanced logging of actual insert data

This completes the fix for the foreign key constraint issue by ensuring users are created with only valid columns.