### PR TITLE
Handle Supabase anon key fallback in config validation

### DIFF
--- a/app/config_validation.py
+++ b/app/config_validation.py
@@ -7,7 +7,7 @@ from app.config import Settings
 
 logger = logging.getLogger("sophia-backend")
 
-MANDATORY_VARS: Iterable[str] = ("SUPABASE_URL", "SUPABASE_KEY")
+MANDATORY_VARS: Iterable[str] = ("SUPABASE_URL",)
 PRODUCTION_ONLY_VARS: Iterable[str] = (
     "MISTRAL_API_KEY",
     "INWORLD_API_KEY",
@@ -37,6 +37,15 @@ def validate_settings(settings: Settings) -> None:
         )
 
     missing_core = _collect_missing(settings, MANDATORY_VARS)
+
+    supabase_key = getattr(settings, "SUPABASE_KEY", None)
+    anon_key = getattr(settings, "SUPABASE_ANON_KEY", None)
+
+    if not supabase_key:
+        missing_core.append("SUPABASE_KEY")
+
+    if not (anon_key or supabase_key):
+        missing_core.append("SUPABASE_ANON_KEY")
     if missing_core:
         missing = ", ".join(missing_core)
         raise SystemExit(

--- a/app/services/supabase.py
+++ b/app/services/supabase.py
@@ -83,6 +83,16 @@ def init_supabase(settings: Optional[Settings] = None) -> Client:
             "Supabase credentials not configured; set SUPABASE_URL and SUPABASE_KEY"
         )
 
+    anon_key = settings.SUPABASE_ANON_KEY or settings.SUPABASE_KEY
+    if not anon_key:
+        raise RuntimeError(
+            "Supabase anon credentials not configured; set SUPABASE_ANON_KEY or SUPABASE_KEY"
+        )
+    if not settings.SUPABASE_ANON_KEY:
+        logger.info(
+            "SUPABASE_ANON_KEY not configured; using SUPABASE_KEY for anon client"
+        )
+
     SUPABASE_BUCKET_AUDIO = settings.SUPABASE_BUCKET_AUDIO or "audio"
     SUPABASE_AUDIO_PREFIX = settings.SUPABASE_AUDIO_PREFIX or "uploads/"
     SUPABASE_SIGNED_URL_TTL = max(
@@ -95,9 +105,7 @@ def init_supabase(settings: Optional[Settings] = None) -> Client:
         options = None
         if ClientOptions is not None:
             options = ClientOptions(persist_session=False)  # type: ignore[arg-type]
-        _anon_supabase = create_client(
-            settings.SUPABASE_URL, settings.SUPABASE_ANON_KEY, options=options
-        )
+        _anon_supabase = create_client(settings.SUPABASE_URL, anon_key, options=options)
     return _supabase
 
 


### PR DESCRIPTION
## Summary
- validate Supabase configuration by requiring an anon key or falling back to the service key when provided
- initialize Supabase clients with the anon key fallback to avoid startup failures when only one key is set

